### PR TITLE
Flytt state ut av router

### DIFF
--- a/src/App/ArbeidsforholdRoutes.tsx
+++ b/src/App/ArbeidsforholdRoutes.tsx
@@ -1,14 +1,7 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { basename } from './paths';
-import environment from '../utils/environment';
-import { APISTATUS } from '../api/api-utils';
-import { Organisasjon, tomaAltinnOrganisasjon } from './Objekter/OrganisasjonFraAltinn';
-import { Arbeidsforhold } from './Objekter/ArbeidsForhold';
-import amplitude from '../utils/amplitude';
-import { loggInfoOmFeil } from './amplitudefunksjonerForLogging';
-import { hentAntallArbeidsforholdFraAareg, hentArbeidsforholdFraAAreg } from '../api/aaregApi';
-import { redirectTilLogin } from './LoggInn/LoggInn';
+import { tomaAltinnOrganisasjon } from './Objekter/OrganisasjonFraAltinn';
 import { OrganisasjonsdetaljerContext } from './OrganisasjonsdetaljerProvider';
 import HovedBanner from './MineAnsatte/HovedBanner/HovedBanner';
 import EnkeltArbeidsforhold from './MineAnsatte/EnkeltArbeidsforhold/EnkeltArbeidsforhold';
@@ -16,28 +9,8 @@ import MineAnsatte from './MineAnsatte/MineAnsatte';
 import IngenTilgangInfo from './IngenTilgangInfo/IngenTilgangInfo';
 import './App.less';
 
-export const MAKS_ANTALL_ARBEIDSFORHOLD = 25000;
-
 const ArbeidsforholdRoutes = () => {
     const { valgtAktivOrganisasjon, tilgangArbeidsforhold } = useContext(OrganisasjonsdetaljerContext);
-
-    const [valgtTidligereVirksomhet, setValgtTidligereVirksomhet] = useState(tomaAltinnOrganisasjon);
-    const [visProgressbar, setVisProgressbar] = useState(false);
-    const [aaregLasteState, setAaregLasteState] = useState<APISTATUS>(APISTATUS.LASTER);
-    const [feilkodeFraAareg, setFeilkodeFraAareg] = useState<string>('');
-
-    const [listeMedArbeidsforholdFraAareg, setListeMedArbeidsforholdFraAareg] = useState(Array<Arbeidsforhold>());
-    const [antallArbeidsforhold, setAntallArbeidsforhold] = useState(0);
-    const [antallArbeidsforholdUkjent, setAntallArbeidsforholdUkjent] = useState(false);
-    const [valgtArbeidsforhold, setValgtArbeidsforhold] = useState<Arbeidsforhold | null>(null);
-
-    const [
-        abortControllerAntallArbeidsforhold,
-        setAbortControllerAntallArbeidsforhold
-    ] = useState<AbortController | null>(null);
-    const [abortControllerArbeidsforhold, setAbortControllerArbeidsforhold] = useState<AbortController | null>(null);
-
-    const [nåværendeUrlString, setNåværendeUrlString] = useState<string>(window.location.href);
 
     const ERPATIDLIGEREARBEIDSFORHOLD = window.location.href.includes('tidligere-arbeidsforhold');
     const enkeltArbeidsforholdPath = ERPATIDLIGEREARBEIDSFORHOLD
@@ -51,115 +24,14 @@ const ArbeidsforholdRoutes = () => {
         }
     }, [valgtAktivOrganisasjon, ERPATIDLIGEREARBEIDSFORHOLD]);
 
-    useEffect(() => {
-        if (environment.MILJO) {
-            amplitude.logEvent('#arbeidsforhold bruker er innlogget');
-        }
-    }, []);
-
-    const hentOgSetAntallOgArbeidsforhold = (organisasjon: Organisasjon, erTidligereVirksomhet: boolean) => {
-        const abortControllerAntallKall = new AbortController();
-        const signal = abortControllerAntallKall.signal;
-        setAbortControllerAntallArbeidsforhold(abortControllerAntallKall);
-
-        setAaregLasteState(APISTATUS.LASTER);
-        setAntallArbeidsforholdUkjent(true);
-        setAntallArbeidsforhold(0);
-
-        hentAntallArbeidsforholdFraAareg(
-            organisasjon.OrganizationNumber,
-            organisasjon.ParentOrganizationNumber,
-            signal
-        ).then(antall => {
-            if (antall === -1) {
-                setVisProgressbar(true);
-            } else if (antall > MAKS_ANTALL_ARBEIDSFORHOLD) {
-                setVisProgressbar(false);
-                setAntallArbeidsforhold(antall);
-                setAaregLasteState(APISTATUS.OK);
-            } else {
-                setAntallArbeidsforholdUkjent(false);
-                setAntallArbeidsforhold(antall);
-                setVisProgressbar(true);
-            }
-            if (antall <= MAKS_ANTALL_ARBEIDSFORHOLD) {
-                const abortControllerArbeidsforhold = new AbortController();
-                setAbortControllerArbeidsforhold(abortControllerArbeidsforhold);
-                const signal = abortControllerArbeidsforhold.signal;
-
-                hentArbeidsforholdFraAAreg(
-                    organisasjon.OrganizationNumber,
-                    organisasjon.ParentOrganizationNumber,
-                    signal,
-                    erTidligereVirksomhet
-                )
-                    .then(respons => {
-                        setListeMedArbeidsforholdFraAareg(respons.arbeidsforholdoversikter);
-                        setAaregLasteState(APISTATUS.OK);
-                        if (antallArbeidsforholdUkjent) {
-                            setAntallArbeidsforhold(respons.arbeidsforholdoversikter.length);
-                        }
-                        if (respons.arbeidsforholdoversikter.length === 0) {
-                            setVisProgressbar(false);
-                        }
-                    })
-                    .catch(error => {
-                        const feilmelding =
-                            'Hent arbeidsforhold fra AAreg feilet: ' + error.response.status
-                                ? error.response.status
-                                : 'Ukjent feil';
-                        loggInfoOmFeil(feilmelding, erTidligereVirksomhet);
-                        if (error.response.status === 401) {
-                            redirectTilLogin();
-                        }
-                        setAaregLasteState(APISTATUS.FEILET);
-                        setFeilkodeFraAareg(error.response.status.toString());
-                    });
-            }
-        });
-    };
-
-    const abortTidligereRequests = () => {
-        if (abortControllerAntallArbeidsforhold && abortControllerArbeidsforhold) {
-            abortControllerAntallArbeidsforhold.abort();
-            abortControllerArbeidsforhold.abort();
-        }
-    };
-
     return (
         <Router basename={basename}>
-            <HovedBanner
-                hentOgSetAntallOgArbeidsforhold={hentOgSetAntallOgArbeidsforhold}
-                abortTidligereRequests={abortTidligereRequests}
-                setEndringIUrlAlert={setNåværendeUrlString}
-            />
+            <HovedBanner />
             <Route exact path={enkeltArbeidsforholdPath}>
-                <EnkeltArbeidsforhold
-                    alleArbeidsforhold={listeMedArbeidsforholdFraAareg}
-                    setVisProgressbar={setVisProgressbar}
-                    valgtArbeidsforhold={valgtArbeidsforhold}
-                    setValgtArbeidsforhold={setValgtArbeidsforhold}
-                />
+                <EnkeltArbeidsforhold />
             </Route>
             <Route exact path={arbeidsforholdPath}>
-                {tilgangArbeidsforhold ? (
-                    <MineAnsatte
-                        hentOgSetAntallOgArbeidsforhold={hentOgSetAntallOgArbeidsforhold}
-                        aaregLasteState={aaregLasteState}
-                        feilkodeFraAareg={feilkodeFraAareg}
-                        valgtTidligereVirksomhet={valgtTidligereVirksomhet}
-                        setTidligereVirksomhet={setValgtTidligereVirksomhet}
-                        listeMedArbeidsforholdFraAareg={listeMedArbeidsforholdFraAareg}
-                        antallArbeidsforhold={antallArbeidsforhold}
-                        antallArbeidsforholdUkjent={antallArbeidsforholdUkjent}
-                        nåværendeUrlString={nåværendeUrlString}
-                        setNåværendeUrlString={setNåværendeUrlString}
-                        visProgressbar={visProgressbar}
-                        setVisProgressbar={setVisProgressbar}
-                    />
-                ) : (
-                    <IngenTilgangInfo />
-                )}
+                {tilgangArbeidsforhold ? <MineAnsatte /> : <IngenTilgangInfo />}
             </Route>
         </Router>
     );

--- a/src/App/MineAnsatte/EnkeltArbeidsforhold/EnkeltArbeidsforhold.tsx
+++ b/src/App/MineAnsatte/EnkeltArbeidsforhold/EnkeltArbeidsforhold.tsx
@@ -28,21 +28,14 @@ const apiURL = () => {
     return 'https://arbeidsgiver-q.nav.no/arbeidsforhold/person/arbeidsforhold-api/arbeidsforholdinnslag/arbeidsgiver/{id}';
 };
 
-interface Props extends RouteComponentProps {
-    alleArbeidsforhold: Arbeidsforhold[];
-    setVisProgressbar: (vis: boolean) => void;
-    valgtArbeidsforhold: Arbeidsforhold | null;
-    setValgtArbeidsforhold: (arbeidsforhold: Arbeidsforhold) => void;
-}
-
-const EnkeltArbeidsforhold: FunctionComponent<Props> = ({
-    history,
-    alleArbeidsforhold,
-    setVisProgressbar,
-    valgtArbeidsforhold,
-    setValgtArbeidsforhold
-}) => {
-    const { valgtAktivOrganisasjon } = useContext(OrganisasjonsdetaljerContext);
+const EnkeltArbeidsforhold: FunctionComponent<RouteComponentProps> = ({ history, }) => {
+    const {
+        valgtAktivOrganisasjon,
+        setVisProgressbar,
+        valgtArbeidsforhold,
+        setValgtArbeidsforhold,
+        listeMedArbeidsforholdFraAareg
+    } = useContext(OrganisasjonsdetaljerContext);
 
     const redirectTilbake = () => {
         const naVærendeUrl = new URL(window.location.href);
@@ -62,7 +55,7 @@ const EnkeltArbeidsforhold: FunctionComponent<Props> = ({
         redirectTilbake();
     }
 
-    const filtrertOgSortertListe: Arbeidsforhold[] = lagListeBasertPaUrl(alleArbeidsforhold);
+    const filtrertOgSortertListe: Arbeidsforhold[] = lagListeBasertPaUrl(listeMedArbeidsforholdFraAareg);
     const indeksValgtArbeidsforhold = filtrertOgSortertListe.findIndex(arbeidsforhold => {
         return arbeidsforhold.navArbeidsforholdId === arbeidsforholdIdFraUrl;
     });

--- a/src/App/MineAnsatte/HovedBanner/HovedBanner.tsx
+++ b/src/App/MineAnsatte/HovedBanner/HovedBanner.tsx
@@ -7,15 +7,16 @@ import { nullStillSorteringIUrlParametere } from '../urlFunksjoner';
 import { OrganisasjonsdetaljerContext } from '../../OrganisasjonsdetaljerProvider';
 import { AltinnorganisasjonerContext } from '../../AltinnorganisasjonerProvider';
 
-interface Props extends RouteComponentProps {
-    hentOgSetAntallOgArbeidsforhold: (organisasjon: Organisasjon, erTidligereArbeidsforhold: boolean) => void;
-    abortTidligereRequests: () => void;
-    setEndringIUrlAlert: (endret: string) => void;
-}
-
-const Banner: FunctionComponent<Props> = props => {
+const Banner: FunctionComponent<RouteComponentProps> = props => {
     const altinnorganisasjoner = useContext(AltinnorganisasjonerContext);
-    const { valgtAktivOrganisasjon, setValgtAktivOrganisasjon, setTilgangTilTidligereArbeidsforhold } = useContext(
+    const {
+        valgtAktivOrganisasjon,
+        setValgtAktivOrganisasjon,
+        setTilgangTilTidligereArbeidsforhold,
+        hentOgSetAntallOgArbeidsforhold,
+        abortTidligereRequests,
+        setNåværendeUrlString
+    } = useContext(
         OrganisasjonsdetaljerContext
     );
 
@@ -37,17 +38,17 @@ const Banner: FunctionComponent<Props> = props => {
         if (organisasjon) {
             setValgtAktivOrganisasjon(organisasjon);
             setTilgangTilTidligereArbeidsforhold(harTilgang(organisasjon.ParentOrganizationNumber));
-            props.abortTidligereRequests();
+            abortTidligereRequests();
 
             if (organisasjon.OrganizationNumber && harTilgang(organisasjon.OrganizationNumber)) {
-                props.hentOgSetAntallOgArbeidsforhold(organisasjon, false);
+                hentOgSetAntallOgArbeidsforhold(organisasjon, false);
             }
 
             if (valgtAktivOrganisasjon !== tomaAltinnOrganisasjon) {
                 history.replace(nullStillSorteringIUrlParametere());
                 erPåEnkeltArbeidsforhold && redirectTilListeVisning();
                 erPåTidligereArbeidsforhold && redirectTilListeVisning();
-                props.setEndringIUrlAlert(window.location.href);
+                setNåværendeUrlString(window.location.href);
             }
         }
     };

--- a/src/App/MineAnsatte/MineAnsatte.tsx
+++ b/src/App/MineAnsatte/MineAnsatte.tsx
@@ -6,7 +6,7 @@ import Chevron from 'nav-frontend-chevron';
 import { APISTATUS } from '../../api/api-utils';
 import { Arbeidsforhold } from '../Objekter/ArbeidsForhold';
 import { Organisasjon, tomaAltinnOrganisasjon } from '../Objekter/OrganisasjonFraAltinn';
-import { OrganisasjonsdetaljerContext } from '../OrganisasjonsdetaljerProvider';
+import { MAKS_ANTALL_ARBEIDSFORHOLD, OrganisasjonsdetaljerContext } from '../OrganisasjonsdetaljerProvider';
 import { lagListeBasertPaUrl } from './sorteringOgFiltreringsFunksjoner';
 import { regnUtantallSider, regnUtArbeidsForholdSomSkalVisesPaEnSide } from './pagineringsFunksjoner';
 import Progressbar from './Progressbar/Progressbar';
@@ -18,7 +18,6 @@ import VelgTidligereVirksomhet from './VelgTidligereVirksomhet/VelgTidligereVirk
 import { nullStillSorteringIUrlParametere } from './urlFunksjoner';
 import { loggTrykketPåTidligereArbeidsforholdSide } from '../amplitudefunksjonerForLogging';
 import Brodsmulesti from '../Brodsmulesti/Brodsmulesti';
-import { MAKS_ANTALL_ARBEIDSFORHOLD } from '../ArbeidsforholdRoutes';
 import './MineAnsatte.less';
 import { AltinnorganisasjonerContext } from '../AltinnorganisasjonerProvider';
 
@@ -48,40 +47,25 @@ const forMangeArbeidsforholdTekst = (antall: number, valgtVirksomhet: String) =>
     );
 };
 
-interface Props extends RouteComponentProps {
-    valgtTidligereVirksomhet: Organisasjon;
-    hentOgSetAntallOgArbeidsforhold: (organisasjon: Organisasjon, erTidligereArbeidsforhold: boolean) => void;
-    listeMedArbeidsforholdFraAareg: Arbeidsforhold[];
-    antallArbeidsforhold: number;
-    visProgressbar: boolean;
-    setVisProgressbar: (skalVises: boolean) => void;
-    aaregLasteState: APISTATUS;
-    feilkodeFraAareg: string;
-    antallArbeidsforholdUkjent: boolean;
-    nåværendeUrlString: string;
-    setNåværendeUrlString: (endret: string) => void;
-    setTidligereVirksomhet: (tidligereVirksomhet: Organisasjon) => void;
-}
-
-const MineAnsatte: FunctionComponent<Props> = ({
-    history,
-    listeMedArbeidsforholdFraAareg,
-    antallArbeidsforhold,
-    antallArbeidsforholdUkjent,
-    visProgressbar,
-    setVisProgressbar,
-    aaregLasteState,
-    feilkodeFraAareg,
-    nåværendeUrlString,
-    setNåværendeUrlString,
-    hentOgSetAntallOgArbeidsforhold,
-    valgtTidligereVirksomhet,
-    setTidligereVirksomhet
-}) => {
+const MineAnsatte: FunctionComponent<RouteComponentProps> = ({ history }) => {
     const altinnorganisasjoner = useContext(AltinnorganisasjonerContext);
-    const { valgtAktivOrganisasjon, tilgangTilTidligereArbeidsforhold, tidligereVirksomheter } = useContext(
-        OrganisasjonsdetaljerContext
-    );
+    const {
+        valgtAktivOrganisasjon,
+        tilgangTilTidligereArbeidsforhold,
+        tidligereVirksomheter,
+        listeMedArbeidsforholdFraAareg,
+        antallArbeidsforhold,
+        antallArbeidsforholdUkjent,
+        visProgressbar,
+        setVisProgressbar,
+        aaregLasteState,
+        feilkodeFraAareg,
+        nåværendeUrlString,
+        setNåværendeUrlString,
+        hentOgSetAntallOgArbeidsforhold,
+        valgtTidligereVirksomhet,
+        setValgtTidligereVirksomhet
+    } = useContext(OrganisasjonsdetaljerContext);
 
     const naVærendeUrl = new URL(nåværendeUrlString);
     const sidetall = naVærendeUrl.searchParams.get('side') || '1';
@@ -115,7 +99,7 @@ const MineAnsatte: FunctionComponent<Props> = ({
     };
 
     const setTidligereVirksomhetHentArbeidsforholdOgNullstillUrlParametere = (organisasjon: Organisasjon) => {
-        setTidligereVirksomhet(organisasjon);
+        setValgtTidligereVirksomhet(organisasjon);
         hentOgSetAntallOgArbeidsforhold(organisasjon, true);
         const search = nullStillSorteringIUrlParametere();
         history.replace({ search: search });

--- a/src/App/MineAnsatte/pagineringsFunksjoner.tsx
+++ b/src/App/MineAnsatte/pagineringsFunksjoner.tsx
@@ -4,33 +4,11 @@ export const regnUtantallSider = (arbeidsForholdPerSide: number, antallArbeidsFo
     return Math.ceil(antallArbeidsForhold / arbeidsForholdPerSide);
 };
 
-export const endreUrlParameter = (url: string, parameter: string, verdi: string) => {
-    const gammelParameter = lesUrlParameter(url, parameter);
-    return url.replace(gammelParameter, verdi);
-};
-
-export const lesUrlParameter = (url: string, parameter: string) => {
-    const posisjonIUrl = url.indexOf(parameter);
-    const startPosisjonParameter = posisjonIUrl + parameter.length + 1;
-    let sluttPosisjonParameter = startPosisjonParameter;
-    for (var i = startPosisjonParameter; i < url.length; i++) {
-        if (url[i] === '&' || i === url.length - 1) {
-            sluttPosisjonParameter = i;
-            break;
-        }
-    }
-    return url.substr(startPosisjonParameter, sluttPosisjonParameter + 1);
-};
-
 export const regnUtArbeidsForholdSomSkalVisesPaEnSide = (
     naVarendeSideTall: number,
     arbeidsForholdPerSide: number,
     listeMedArbeidsForhold: Arbeidsforhold[]
 ): Arbeidsforhold[] => {
     const forsteElementPaSiden = arbeidsForholdPerSide * naVarendeSideTall - (arbeidsForholdPerSide - 1);
-    const arbeidsForholdPaSiden = listeMedArbeidsForhold.slice(
-        forsteElementPaSiden - 1,
-        forsteElementPaSiden + (arbeidsForholdPerSide - 1)
-    );
-    return arbeidsForholdPaSiden;
+    return listeMedArbeidsForhold.slice(forsteElementPaSiden - 1, forsteElementPaSiden + (arbeidsForholdPerSide - 1));
 };

--- a/src/App/MineAnsatte/sorteringOgFiltreringsFunksjoner.tsx
+++ b/src/App/MineAnsatte/sorteringOgFiltreringsFunksjoner.tsx
@@ -1,17 +1,15 @@
 import { SyntheticEvent } from 'react';
 import { ToggleKnappPureProps } from 'nav-frontend-toggle';
-import {SorteringsAttributt} from './MineAnsatte';
+import { SorteringsAttributt } from './MineAnsatte';
 import { Arbeidsforhold } from '../Objekter/ArbeidsForhold';
 import { byggArbeidsforholdSokeresultat } from './Sokefelt/byggArbeidsforholdSokeresultat';
 
 export const lagListeBasertPaUrl = (alleArbeidsforhold: Arbeidsforhold[]) => {
-    const sortertPå = getVariabelFraUrl('sorter') || '0'
+    const sortertPå = getVariabelFraUrl('sorter') || '0';
     const reversSortering = getVariabelFraUrl('revers') ? getVariabelFraUrl('revers') === 'true' : true;
     const filtreringsvalg = getVariabelFraUrl('filter') || 'Alle';
     const sokefeltTekst = getVariabelFraUrl('sok') || '';
     const filtrertPaVarsler = getVariabelFraUrl('varsler') === 'true';
-
-
 
     const filtrertListe = byggListeBasertPaPArametere(
         alleArbeidsforhold,
@@ -19,9 +17,10 @@ export const lagListeBasertPaUrl = (alleArbeidsforhold: Arbeidsforhold[]) => {
         filtrertPaVarsler,
         sokefeltTekst
     );
-    const filtrertOgSortertListe: Arbeidsforhold[] = reversSortering ?  sorterArbeidsforhold(filtrertListe, parseInt(sortertPå)).reverse() : sorterArbeidsforhold(filtrertListe, parseInt(sortertPå));
-    return filtrertOgSortertListe
-}
+    return reversSortering
+        ? sorterArbeidsforhold(filtrertListe, parseInt(sortertPå)).reverse()
+        : sorterArbeidsforhold(filtrertListe, parseInt(sortertPå));
+};
 
 export const byggListeBasertPaPArametere = (
     originalListe: Arbeidsforhold[],
@@ -197,7 +196,7 @@ export const tellAntallAktiveOgInaktiveArbeidsforhold = (listeMedArbeidsforhold:
 };
 
 export const filtrerPaVarsler = (listeMedArbeidsforhold: Arbeidsforhold[], filtrerPaVarsler: boolean) => {
-    const filtrertPaVarsler = listeMedArbeidsforhold.filter(forhold => {
+    return listeMedArbeidsforhold.filter(forhold => {
         if (forhold.varsler && filtrerPaVarsler) {
             if (forhold.varsler.length) {
                 return forhold;
@@ -208,13 +207,12 @@ export const filtrerPaVarsler = (listeMedArbeidsforhold: Arbeidsforhold[], filtr
         }
         return null;
     });
-    return filtrertPaVarsler;
 };
 
 export const getVariabelFraUrl = (variabel: string) => {
     const url = new URL(window.location.href);
     return url.searchParams.get(variabel);
-}
+};
 
 export const filtreringValgt = (event: SyntheticEvent<EventTarget>, toggles: ToggleKnappPureProps[]): string => {
     let valg = 'Alle';

--- a/src/App/OrganisasjonsdetaljerProvider.tsx
+++ b/src/App/OrganisasjonsdetaljerProvider.tsx
@@ -1,8 +1,17 @@
 import React, { createContext, FunctionComponent, useContext, useEffect, useState } from 'react';
 import { Organisasjon, tomaAltinnOrganisasjon } from './Objekter/OrganisasjonFraAltinn';
-import { hentTidligereVirksomheter } from '../api/aaregApi';
-import { loggInfoOmFeilTidligereOrganisasjoner } from './amplitudefunksjonerForLogging';
+import {
+    hentAntallArbeidsforholdFraAareg,
+    hentArbeidsforholdFraAAreg,
+    hentTidligereVirksomheter
+} from '../api/aaregApi';
+import { loggInfoOmFeil, loggInfoOmFeilTidligereOrganisasjoner } from './amplitudefunksjonerForLogging';
 import { AltinnorganisasjonerContext } from './AltinnorganisasjonerProvider';
+import { APISTATUS } from '../api/api-utils';
+import { Arbeidsforhold } from './Objekter/ArbeidsForhold';
+import environment from '../utils/environment';
+import amplitude from '../utils/amplitude';
+import { redirectTilLogin } from './LoggInn/LoggInn';
 
 type Context = {
     valgtAktivOrganisasjon: Organisasjon;
@@ -11,9 +20,28 @@ type Context = {
     tilgangTilTidligereArbeidsforhold: boolean;
     setTilgangTilTidligereArbeidsforhold: (bool: boolean) => void;
     tidligereVirksomheter: Organisasjon[] | undefined;
+
+    hentOgSetAntallOgArbeidsforhold: (organisasjon: Organisasjon, erTidligereArbeidsforhold: boolean) => void;
+    abortTidligereRequests: () => void;
+    setNåværendeUrlString: (url: string) => void;
+    setVisProgressbar: (vis: boolean) => void;
+    valgtArbeidsforhold: Arbeidsforhold | null;
+    setValgtArbeidsforhold: (arbeidsforhold: Arbeidsforhold) => void;
+    listeMedArbeidsforholdFraAareg: Arbeidsforhold[];
+
+    valgtTidligereVirksomhet: Organisasjon;
+    antallArbeidsforhold: number;
+    visProgressbar: boolean;
+    aaregLasteState: APISTATUS;
+    feilkodeFraAareg: string;
+    antallArbeidsforholdUkjent: boolean;
+    nåværendeUrlString: string;
+    setValgtTidligereVirksomhet: (tidligereVirksomhet: Organisasjon) => void;
 };
 
 export const OrganisasjonsdetaljerContext = createContext<Context>({} as Context);
+
+export const MAKS_ANTALL_ARBEIDSFORHOLD = 25000;
 
 export const OrganisasjonsdetaljerProvider: FunctionComponent = props => {
     const altinnorganisasjoner = useContext(AltinnorganisasjonerContext);
@@ -40,13 +68,121 @@ export const OrganisasjonsdetaljerProvider: FunctionComponent = props => {
         }
     }, [valgtAktivOrganisasjon.ParentOrganizationNumber, tilgangTilTidligereArbeidsforhold]);
 
+    const [valgtTidligereVirksomhet, setValgtTidligereVirksomhet] = useState(tomaAltinnOrganisasjon);
+    const [visProgressbar, setVisProgressbar] = useState(false);
+    const [aaregLasteState, setAaregLasteState] = useState<APISTATUS>(APISTATUS.LASTER);
+    const [feilkodeFraAareg, setFeilkodeFraAareg] = useState<string>('');
+
+    const [listeMedArbeidsforholdFraAareg, setListeMedArbeidsforholdFraAareg] = useState(Array<Arbeidsforhold>());
+    const [antallArbeidsforhold, setAntallArbeidsforhold] = useState(0);
+    const [antallArbeidsforholdUkjent, setAntallArbeidsforholdUkjent] = useState(false);
+    const [valgtArbeidsforhold, setValgtArbeidsforhold] = useState<Arbeidsforhold | null>(null);
+
+    const [
+        abortControllerAntallArbeidsforhold,
+        setAbortControllerAntallArbeidsforhold
+    ] = useState<AbortController | null>(null);
+    const [abortControllerArbeidsforhold, setAbortControllerArbeidsforhold] = useState<AbortController | null>(null);
+
+    const [nåværendeUrlString, setNåværendeUrlString] = useState<string>(window.location.href);
+
+    useEffect(() => {
+        if (environment.MILJO) {
+            amplitude.logEvent('#arbeidsforhold bruker er innlogget');
+        }
+    }, []);
+
+    const hentOgSetAntallOgArbeidsforhold = (organisasjon: Organisasjon, erTidligereVirksomhet: boolean) => {
+        const abortControllerAntallKall = new AbortController();
+        const signal = abortControllerAntallKall.signal;
+        setAbortControllerAntallArbeidsforhold(abortControllerAntallKall);
+
+        setAaregLasteState(APISTATUS.LASTER);
+        setAntallArbeidsforholdUkjent(true);
+        setAntallArbeidsforhold(0);
+
+        hentAntallArbeidsforholdFraAareg(
+            organisasjon.OrganizationNumber,
+            organisasjon.ParentOrganizationNumber,
+            signal
+        ).then(antall => {
+            if (antall === -1) {
+                setVisProgressbar(true);
+            } else if (antall > MAKS_ANTALL_ARBEIDSFORHOLD) {
+                setVisProgressbar(false);
+                setAntallArbeidsforhold(antall);
+                setAaregLasteState(APISTATUS.OK);
+            } else {
+                setAntallArbeidsforholdUkjent(false);
+                setAntallArbeidsforhold(antall);
+                setVisProgressbar(true);
+            }
+            if (antall <= MAKS_ANTALL_ARBEIDSFORHOLD) {
+                const abortControllerArbeidsforhold = new AbortController();
+                setAbortControllerArbeidsforhold(abortControllerArbeidsforhold);
+                const signal = abortControllerArbeidsforhold.signal;
+
+                hentArbeidsforholdFraAAreg(
+                    organisasjon.OrganizationNumber,
+                    organisasjon.ParentOrganizationNumber,
+                    signal,
+                    erTidligereVirksomhet
+                )
+                    .then(respons => {
+                        setListeMedArbeidsforholdFraAareg(respons.arbeidsforholdoversikter);
+                        setAaregLasteState(APISTATUS.OK);
+                        if (antallArbeidsforholdUkjent) {
+                            setAntallArbeidsforhold(respons.arbeidsforholdoversikter.length);
+                        }
+                        if (respons.arbeidsforholdoversikter.length === 0) {
+                            setVisProgressbar(false);
+                        }
+                    })
+                    .catch(error => {
+                        const feilmelding =
+                            'Hent arbeidsforhold fra AAreg feilet: ' + error.response.status
+                                ? error.response.status
+                                : 'Ukjent feil';
+                        loggInfoOmFeil(feilmelding, erTidligereVirksomhet);
+                        if (error.response.status === 401) {
+                            redirectTilLogin();
+                        }
+                        setAaregLasteState(APISTATUS.FEILET);
+                        setFeilkodeFraAareg(error.response.status.toString());
+                    });
+            }
+        });
+    };
+
+    const abortTidligereRequests = () => {
+        if (abortControllerAntallArbeidsforhold && abortControllerArbeidsforhold) {
+            abortControllerAntallArbeidsforhold.abort();
+            abortControllerArbeidsforhold.abort();
+        }
+    };
+
     const context: Context = {
         valgtAktivOrganisasjon,
         setValgtAktivOrganisasjon,
         tilgangArbeidsforhold,
         tilgangTilTidligereArbeidsforhold,
         setTilgangTilTidligereArbeidsforhold,
-        tidligereVirksomheter
+        tidligereVirksomheter,
+        setNåværendeUrlString,
+        setValgtArbeidsforhold,
+        setValgtTidligereVirksomhet,
+        setVisProgressbar,
+        hentOgSetAntallOgArbeidsforhold,
+        aaregLasteState,
+        abortTidligereRequests,
+        antallArbeidsforhold,
+        antallArbeidsforholdUkjent,
+        feilkodeFraAareg,
+        listeMedArbeidsforholdFraAareg,
+        valgtArbeidsforhold,
+        valgtTidligereVirksomhet,
+        visProgressbar,
+        nåværendeUrlString
     };
 
     return (


### PR DESCRIPTION
Flytter tilstander ut av routeren inn i den utenforliggende Organisasjonsdetaljer-provideren.
Det skal ikke være gjort noen endringer i logikken.

Testet med mock og i dev. 